### PR TITLE
Only push a version tag when there's a matching git tag

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -115,8 +115,10 @@ docker build -t balena/$ARCH-supervisor-base:$TAG $WORKSPACE
 if [ "$PUSH" = "true" ]; then
 	docker push balena/$ARCH-supervisor-base:$TAG
 
-	if [ "$TAG" = "master" ]; then
-		VERSION_TAG=v$(jq --raw-output .version package.json)
+	VERSION_TAG=v$(jq --raw-output .version package.json)
+	GIT_TAG=$(git describe --tags | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || echo "")
+	echo "git tag is '$GIT_TAG' and package.json version is '$VERSION_TAG'"
+	if [ "${VERSION_TAG}" = "${GIT_TAG}" ]; then
 		docker tag balena/$ARCH-supervisor-base:$TAG balena/$ARCH-supervisor-base:$VERSION_TAG
 		docker push balena/$ARCH-supervisor-base:$VERSION_TAG
 	fi


### PR DESCRIPTION
This avoids overwriting old versions when there's a merge to master that is built
before versionbot bumps package.json.

Change-type: patch
Signed-off-by: Pablo Carranza Velez <pablocarranza@gmail.com>

(same as we did in https://github.com/balena-io/balena-supervisor/pull/776 )