### PR TITLE
local.conf.sample: Stop installing btrfs-tools

### DIFF
--- a/build-samples/local.conf.sample
+++ b/build-samples/local.conf.sample
@@ -231,6 +231,6 @@ DISTRO_FEATURES_BACKFILL_CONSIDERED += "gobject-introspection-data"
 # to consider it provided.
 ASSUME_PROVIDED += "gobject-introspection gobject-introspection-native"
 
-IMAGE_INSTALL_append += " btrfs-tools ca-certificates iptables libnss-mdns nodejs rsync"
+IMAGE_INSTALL_append += " ca-certificates iptables libnss-mdns nodejs rsync"
 VIRTUAL-RUNTIME_init_manager="busybox"
 VIRTUAL-RUNTIME_dev_manager="busybox-mdev"


### PR DESCRIPTION
In a far away universe, balenaOS was deploying images with BTRFS
filesystems. That universe died and a new one based on AUFS and
OverlayFS took its place.
As well the scattered devices from the old universe are not meant to run
a supervisor newer than 6.x.

Change-type: patch
Signed-off-by: Andrei Gherzan <andrei@balena.io>