### PR TITLE
ca-certificates: Fix the openssl(-bin) dependency

### DIFF
--- a/meta-balena-supervisor/recipes-support/ca-certificates/ca-certificates_%.bbappend
+++ b/meta-balena-supervisor/recipes-support/ca-certificates/ca-certificates_%.bbappend
@@ -1,0 +1,1 @@
+RDEPENDS_${PN} += "openssl-bin"


### PR DESCRIPTION
Since yocto thud, and more specifically since poky switched to
openssl 1.1 line, the openssl binary is provided by 'openssl-bin'.

Change-type: patch
Signed-off-by: Andrei Gherzan <andrei@balena.io>